### PR TITLE
feat(main): return error if config file isn't found

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func (c *conf) getConf() (*conf, error) {
 
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall configuration file into yaml: %v")
+		return nil, fmt.Errorf("failed to unmarshall configuration file into yaml: %v", err)
 	}
 
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -17,25 +17,34 @@ type conf struct {
 	Token string `yaml:"token"`
 }
 
-func (c *conf) getConf() *conf {
-
+func (c *conf) getConf() (*conf, error) {
 	yamlFile, err := ioutil.ReadFile("config.yaml")
 	if err != nil {
-		log.Printf("yamlFile.Get err   #%v ", err)
-	}
-	err = yaml.Unmarshal(yamlFile, c)
-	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+		return nil, fmt.Errorf("failed to read configuration file: %v", err)
 	}
 
-	return c
+	err = yaml.Unmarshal(yamlFile, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall configuration file into yaml: %v")
+	}
+
+	return c, nil
 }
 
 func main() {
 
 	// Token token for the Discord Bot as part of interacting with their API
 	var c conf
-	var Token = c.getConf().Token
+	
+	// read the configuration file, panic if it's not found
+	configFile, err := c.getConf()
+	if err != nil {
+		panic(err)
+	}
+	
+	// this should probably be set to lowercase since we don't usually want
+	// to export things in the main package.
+	Token := configFile.Token
 
 	// Create a new Discord session using the provided bot token.
 	dg, err := discordgo.New("Bot " + Token)


### PR DESCRIPTION
**What this PR does**: Adds a `error` return value to `c.getConf` this allows us to better parse when the configuration file isn't found on runtime.

We can also wrap this in a `Must(c *conf, e error) *conf` function that could panic if it's not found. i.e example invocation:

```go
// Must panics if a configuration file can't be loaded
func Must(c *conf, e error) *conf {
  if err != nil {
    panic(err)
  }

  return c
}

conf := c.Must(c.getConf())
```

That could be used for scenarios where we need to load the file, but since this is configuration I don't think we'll have any scenarios where we need to load it (usually done for global vars)